### PR TITLE
Point to latest examples

### DIFF
--- a/docs/content/_index.en.md
+++ b/docs/content/_index.en.md
@@ -96,4 +96,4 @@ Usage
   Hello, world!
 ```
 
-See the [examples](https://github.com/fission/fission/tree/0.6.0/examples) directory for more.
+See the [examples](https://github.com/fission/fission/tree/master/examples) directory for more.


### PR DESCRIPTION
Point to latest examples instead of version specific once. The version-specific once tend to get out of date and need manual intervention.