### PR TITLE
Adding the routerServiceType for Minikube

### DIFF
--- a/docs/content/installation/installation.en.md
+++ b/docs/content/installation/installation.en.md
@@ -75,7 +75,7 @@ $ helm init
 #### Minikube
 
 ```sh
-$ helm install --namespace fission --set serviceType=NodePort https://github.com/fission/fission/releases/download/0.7.1/fission-all-0.7.1.tgz
+$ helm install --namespace fission --set serviceType=NodePort --set routerServiceType=NodePort https://github.com/fission/fission/releases/download/0.7.1/fission-all-0.7.1.tgz
 ```
 
 The serviceType variable allows configuring the type of Kubernetes


### PR DESCRIPTION
Including --set routerServiceType=NodePort which is required for minikube installation.