### PR TITLE
Update to latest minikube release

### DIFF
--- a/docs/content/installation/kubernetessetup.en.md
+++ b/docs/content/installation/kubernetessetup.en.md
@@ -19,7 +19,7 @@ Minikube is the usual way to run Kubernetes on your laptop:
 ```
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin
 
-$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.16.0/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.26.1/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 $ minikube start
 ```
@@ -29,7 +29,7 @@ $ minikube start
 ```
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin
 
-$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.16.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.26.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 $ minikube start
 ```


### PR DESCRIPTION
With minikube v0.16.0, I get "Error: apiVersion "rbac.authorization.k8s.io/v1beta1" in fission-all/templates/deployment.yaml is not available". Upgrading to minikube v0.26.1 fixes this issue.