### PR TITLE
adding spec option to create the yaml file

### DIFF
--- a/docs/content/tutorial/developer-workflow.md
+++ b/docs/content/tutorial/developer-workflow.md
@@ -160,9 +160,9 @@ specifies the function name, where the code lives, and associates the
 function with the python environment:
 
 ```
-fission function create --name calc-form --env python --source form.py --entrypoint form.main
+fission function create --spec --name calc-form --env python --source form.py --entrypoint form.main
 
-fission function create --name calc-eval --env python --source calc.py --entrypoint calc.main
+fission function create --spec --name calc-eval --env python --source calc.py --entrypoint calc.main
 ```
 
 You can see the generated YAML files in


### PR DESCRIPTION
I was struggling to understand why the command 

`fission specs validate`

was giving me the error:

```
* specs/route-3cfa1f06-33ea-44c6-9e1a-9955e1335675.yaml:1: HTTPTrigger '3cfa1f06-33ea-44c6-9e1a-9955e1335675' references unknown function 'calc-form'
* specs/route-dd181fbe-0f01-44d4-8da4-7986924ac8d2.yaml:1: HTTPTrigger 'dd181fbe-0f01-44d4-8da4-7986924ac8d2' references unknown function 'calc-eval'
```

Reading through the documentation I saw a YAML file was supposed to be created.  Reading through the `--help` docs, I realized a switch is missing in the CLI to generate the files.