### PR TITLE
Use latest instead of specific version

### DIFF
--- a/docs/content/installation/kubernetessetup.en.md
+++ b/docs/content/installation/kubernetessetup.en.md
@@ -19,7 +19,7 @@ Minikube is the usual way to run Kubernetes on your laptop:
 ```
 $ curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin
 
-$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.26.1/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 $ minikube start
 ```


### PR DESCRIPTION
At the time of writing 0.28.1 is out while the docs still point to 0.26.1 producing this warning when running minikube the first time: 

```
There is a newer version of minikube available (v0.28.1).  Download it here:
https://github.com/kubernetes/minikube/releases/tag/v0.28.1
```

Using the `latest` keyword should always retrieve the latest version.