### PR TITLE
Helm dep bash

### DIFF
--- a/docs/content/contributing/_index.en.md
+++ b/docs/content/contributing/_index.en.md
@@ -28,46 +28,46 @@ minikube, you'll need to set the proper environment variables with
 
 Install dependencies with glide:
 
-```bash
-  $ glide install
-```
+{{< highlight bash >}}
+$ glide install
+{{< /highlight >}}
 
 Build fission server:
 
-```bash
-  $ pushd fission-bundle
-  $ ./build.sh
-```
+{{< highlight bash >}}
+$ pushd fission-bundle
+$ ./build.sh
+{{< /highlight >}}
 
 You now need to build the docker image for fission. You can use
 `push.sh` and push it to a docker hub account. But it's easiest to use
 minikube and its built-in docker daemon:
 
-```bash
-  $ eval $(minikube docker-env)
-  $ docker build -t minikube/fission-bundle .
-```
+{{< highlight bash >}}
+$ eval $(minikube docker-env)
+$ docker build -t minikube/fission-bundle .
+{{< /highlight >}}
 
 Next, pull in the dependencies for the Helm chart:
 
-```bash
-  $ helm dep update charts/fission-all
-```
+{{< highlight bash >}}
+$ helm dep update charts/fission-all
+{{< /highlight >}}
 
 Next, install fission with this image on your kubernetes cluster using the helm chart:
 
-```bash
-  $ helm install --set "image=minikube/fission-bundle,pullPolicy=IfNotPresent,analytics=false" charts/fission-all
-```
+{{< highlight bash >}}
+$ helm install --set "image=minikube/fission-bundle,pullPolicy=IfNotPresent,analytics=false" charts/fission-all
+{{< /highlight >}}
 
 And if you're changing the CLI too, you can build it with:
 
-```bash
-  $ cd fission && go install
-```
+{{< highlight bash >}}
+$ cd fission && go install
+{{< /highlight >}}
 
 Finally, reset to the original current working directory
 
-```bash
-  $ popd
-```
+{{< highlight bash >}}
+$ popd
+{{< /highlight >}}

--- a/docs/content/contributing/_index.en.md
+++ b/docs/content/contributing/_index.en.md
@@ -26,11 +26,15 @@ directory (if you want to build the image with the docker inside
 minikube, you'll need to set the proper environment variables with
 `eval $(minikube docker-env)`):
 
-```
-  # Get dependencies
-  $ glide install
+Install dependencies with glide:
 
-  # Build fission server and an image
+```bash
+  $ glide install
+```
+
+Build fission server:
+
+```bash
   $ pushd fission-bundle
   $ ./build.sh
 ```
@@ -39,32 +43,31 @@ You now need to build the docker image for fission. You can use
 `push.sh` and push it to a docker hub account. But it's easiest to use
 minikube and its built-in docker daemon:
 
-```
+```bash
   $ eval $(minikube docker-env)
   $ docker build -t minikube/fission-bundle .
 ```
 
 Next, pull in the dependencies for the Helm chart:
 
-```
+```bash
   $ helm dep update charts/fission-all
 ```
 
 Next, install fission with this image on your kubernetes cluster using the helm chart:
 
-```
+```bash
   $ helm install --set "image=minikube/fission-bundle,pullPolicy=IfNotPresent,analytics=false" charts/fission-all
 ```
 
 And if you're changing the CLI too, you can build it with:
 
-```
-  # Build Fission CLI
+```bash
   $ cd fission && go install
 ```
 
 Finally, reset to the original current working directory
 
-```
+```bash
   $ popd
 ```

--- a/docs/content/contributing/_index.en.md
+++ b/docs/content/contributing/_index.en.md
@@ -44,6 +44,12 @@ minikube and its built-in docker daemon:
   $ docker build -t minikube/fission-bundle .
 ```
 
+Next, pull in the dependencies for the Helm chart:
+
+```
+  $ helm dep update charts/fission-all
+```
+
 Next, install fission with this image on your kubernetes cluster using the helm chart:
 
 ```
@@ -55,4 +61,10 @@ And if you're changing the CLI too, you can build it with:
 ```
   # Build Fission CLI
   $ cd fission && go install
+```
+
+Finally, reset to the original current working directory
+
+```
+  $ popd
 ```

--- a/docs/content/contributing/_index.en.md
+++ b/docs/content/contributing/_index.en.md
@@ -29,13 +29,13 @@ minikube, you'll need to set the proper environment variables with
 Install dependencies with glide:
 
 {{< highlight bash >}}
-$ glide install
+$ glide install -v
 {{< /highlight >}}
 
 Build fission server:
 
 {{< highlight bash >}}
-$ pushd fission-bundle
+$ pushd $GOPATH/src/github.com/fission/fission/fission-bundle
 $ ./build.sh
 {{< /highlight >}}
 
@@ -51,7 +51,7 @@ $ docker build -t minikube/fission-bundle .
 Next, pull in the dependencies for the Helm chart:
 
 {{< highlight bash >}}
-$ helm dep update charts/fission-all
+$ helm dep update $GOPATH/src/github.com/fisson/charts/fission-all
 {{< /highlight >}}
 
 Next, install fission with this image on your kubernetes cluster using the helm chart:
@@ -63,7 +63,8 @@ $ helm install --set "image=minikube/fission-bundle,pullPolicy=IfNotPresent,anal
 And if you're changing the CLI too, you can build it with:
 
 {{< highlight bash >}}
-$ cd fission && go install
+$ cd $GOPATH/src/github.com/fission/fission/fission
+$ go install
 {{< /highlight >}}
 
 Finally, reset to the original current working directory


### PR DESCRIPTION
```
    Mark documentation with bash tag
    
    Copy and paste from the webpage do not work properly
    in Hugo without a bash tag.  The page has been slightly
    restructured to work with the bash tag.
```

```
    Add helm dep update step
    
    Currently the Helm charts will not render as specified
    in this document.  The helm charts are likely packaged with
    `helm package -u charts/*` when uploaded to
    https://github.com/fission/fission-charts.  During developer
    workflows, this doesn't happen and the helm dep step must
    be run manually.
    
    Also add a popd as the directory is pushed into the bash stack.
```