### PR TITLE
Fix typo in canary-deployments.md

### DIFF
--- a/docs/content/usage/canary-deployments.md
+++ b/docs/content/usage/canary-deployments.md
@@ -11,7 +11,7 @@ This tutorial will walk you through setting up a canary config to deploy a new v
 Canary feature can be enabled or disabled by setting a feature flag in helm chart `canaryDeployment.enabled` to true or false during fission installation.
 
 This feature is dependent on **Prometheus** metrics to check the health of the new version of the function. Hence, Prometheus is listed as a dependency for fission chart. 
-Either an existing prometheus deployment in the cluster can be used or Prometheus could be installed alon with fission.
+Either an existing prometheus deployment in the cluster can be used or Prometheus could be installed along with fission.
 To install prometheus with fission, the flag prometheusDeploy can be set to True in the helm chart.
 In order to re-use existing Prometheus deployment, fission checks the value of Prometheus server service environment variable in its controller pod. If that cant be accessed, fission proceeds without enabling the canary feature.
 


### PR DESCRIPTION
`alon` -> `along`