### PR TITLE
Use go-1.12 for building packages to avoid go mod errors

### DIFF
--- a/docs/content/usage/kafka-trigger-tutorial.md
+++ b/docs/content/usage/kafka-trigger-tutorial.md
@@ -87,7 +87,7 @@ With these two files in a directory, run the command `glide install -v`. The res
 We are now ready to package this code and create a function so that we can execute it later. Following commands will create a environment, package and function. Verify that build for package succeeded before proceeding.
 
 ``` sh
-$ fission env create --name goenv --image fission/go-env --builder fission/go-builder
+$ fission env create --name goenv --image fission/go-env --builder fission/go-builder-1.12
 $ zip -qr kafka.zip * 
 $ fission package create --env goenv --src kafka.zip
 Package 'kafka-zip-tzsu' created


### PR DESCRIPTION
- using normal go-builder (go < 1.12) leads to failure when building because the command 'go mod' does not work