### PR TITLE
Fission kubernetes version for fission

### DIFF
--- a/docs/content/en/docs/installation/_index.en.md
+++ b/docs/content/en/docs/installation/_index.en.md
@@ -23,7 +23,7 @@ Helm](#without-helm).
 If you don't have a Kubernetes cluster, [here's a official guide to set one up](https://kubernetes.io/docs/setup/).
 
 {{% notice info %}}
-Fission requires Kubernetes 1.9 or higher
+Fission requires Kubernetes 1.6 or higher
 {{% /notice %}}
 
 ## Kubectl

--- a/docs/content/en/docs/installation/_index.en.md
+++ b/docs/content/en/docs/installation/_index.en.md
@@ -23,7 +23,7 @@ Helm](#without-helm).
 If you don't have a Kubernetes cluster, [here's a official guide to set one up](https://kubernetes.io/docs/setup/).
 
 {{% notice info %}}
-Fission requires Kubernetes 1.6 or higher
+Fission requires Kubernetes 1.16 or higher
 {{% /notice %}}
 
 ## Kubectl


### PR DESCRIPTION
Fission 1.8 works on Kubernetes 1.16
Fixing the typo 

```
[root@ilgss0436 ~]# kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.1", GitCommit:"d647ddbd755faf07169599a625faf302ffc34458", GitTreeState:"clean", BuildDate:"2019-10-02T17:01:15Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.1", GitCommit:"d647ddbd755faf07169599a625faf302ffc34458", GitTreeState:"clean", BuildDate:"2019-10-02T16:51:36Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}



[root@ilgss0436 ~]# fission version
client:
  fission/core:
    BuildDate: "2020-02-03T08:40:57Z"
    GitCommit: bda974a72c9093e241c1dae6a7fc1a2d16e28b02
    Version: 1.8.0
server:
  fission/core:
    BuildDate: "2020-02-03T08:40:57Z"
    GitCommit: bda974a72c9093e241c1dae6a7fc1a2d16e28b02
    Version: 1.8.0
[root@ilgss0436 ~]#
```