### PR TITLE
Fix notice shortcode tags

### DIFF
--- a/docs/content/en/docs/concepts/components/core/executor.md
+++ b/docs/content/en/docs/concepts/components/core/executor.md
@@ -127,6 +127,6 @@ You can set the initial and maximum CPU for a function and target CPU at which a
 Autoscaling is useful for workloads where you expect intermittant spikes in workloads.
 It also enables optimal the usage of resources to execute functions, by using a baseline capacity with minimum scale and ability to burst up to maximum scale based on spikes in demand.
 
-{{% notice info %}}
+{{< notice info >}}
 Learn more further usage/setup of **executor type** for functions, please see [here]({{% ref "../../../usage/executor.en.md" %}}).
-{{% /notice %}}
+{{< /notice >}}

--- a/docs/content/en/docs/installation/_index.en.md
+++ b/docs/content/en/docs/installation/_index.en.md
@@ -22,9 +22,9 @@ Helm](#without-helm).
 
 If you don't have a Kubernetes cluster, [here's a official guide to set one up](https://kubernetes.io/docs/setup/).
 
-{{% notice info %}}
+{{< notice info >}}
 Fission requires Kubernetes 1.9 or higher
-{{% /notice %}}
+{{< /notice >}}
 
 ## Kubectl
 
@@ -46,9 +46,9 @@ the next section](#install-fission).
 To install helm, first you'll need the helm CLI. Visit [here](https://helm.sh/docs/intro/install/) 
 to see how to install it.
 
-{{% notice info %}}
+{{< notice info >}}
 You can skip the following and head over [Fission installation](#install-fission) if you're using Helm **v3**.
-{{% /notice %}}
+{{< /notice >}}
 
 Next, install the Helm server on your Kubernetes cluster.  Before you
 do that, you have to give helm's server privileges to install software
@@ -210,9 +210,9 @@ anything in it. Create namespace for fission installation.
 $ kubectl create namespace fission 
 ```
   
-{{% notice info %}}
+{{< notice info >}}
 * If you want to install in another namespace, please consider to use `helm`.
-{{% /notice %}}
+{{< /notice >}}
 
 Choose _one_ of the following commands to run:
 

--- a/docs/content/en/docs/installation/advanced-setup.en.md
+++ b/docs/content/en/docs/installation/advanced-setup.en.md
@@ -116,10 +116,10 @@ router.displayAccessLog=true
 when using helm to deploy 1.7.0. Or, you can change the environment variable 
 `DISPLAY_ACCESS_LOG` of router deployment to `"true"`.  
 
-{{% notice warning %}}
+{{< notice warning >}}
 Once enabling endpoint access log, the router resource 
 utilization increases when under heavy workloads.
-{{% /notice %}}
+{{< /notice >}}
 
 ## ProbabilitySampler in router
 
@@ -169,6 +169,6 @@ Or, you can enable it by modifying environment variable of deployment of executo
   value: "true"
 ```
 
-{{% notice warning %}}
+{{< notice warning >}}
 The executor will still delete resources when you upgrade from a version prior 1.7.0 even the feature is enabled.
-{{% /notice %}}
+{{< /notice >}}

--- a/docs/content/en/docs/installation/env_vars.en.md
+++ b/docs/content/en/docs/installation/env_vars.en.md
@@ -7,9 +7,9 @@ description: >
 
 ## Namespace
 
-{{% notice info %}}
+{{< notice info >}}
 You only need to set this if there are multiple Fission installations in **different namespaces** within the same Kubernetes cluster.
-{{% /notice %}}
+{{< /notice >}}
 
 Set `FISSION_NAMESPACE` to the namespace where the Fission installed.
 
@@ -19,14 +19,14 @@ $ export FISSION_NAMESPACE <namespace>
 
 ## Fission Router Address
 
-{{% notice info %}}
+{{< notice info >}}
 You don't need to set this if you're simply running `fission function test --name <fn>`, because Fission CLI uses **local port-forward** mechanism to talk to router pod.  
-{{% /notice %}}
+{{< /notice >}}
 
-{{% notice warning %}}
+{{< notice warning >}}
 Fission CLI uses value in `FISSION_ROUTER` if it's not empty instead of using local port-forward mechanism.</br>
 You need to ensure that the IP address in it is **accessible** from the public network.
-{{% /notice %}}
+{{< /notice >}}
 
 It's convenient to set the `FISSION_ROUTER` environment variable to the **externally-visible** address of the Fission router.
 

--- a/docs/content/en/docs/languages/_index.md
+++ b/docs/content/en/docs/languages/_index.md
@@ -51,6 +51,6 @@ The following pre-built environments are currently available for use in Fission:
 | .NET                                | `fission/dotnet-env`      | -                          | O   | X   | X   |
 | Perl                                | `fission/perl-env`        | -                          | O   | X   | X   |
 
-{{% notice info %}}
+{{< notice info >}}
 You can find the latest image tags by searching image name at [Fission Dockerhub](https://hub.docker.com/u/fission/).
-{{% /notice %}}
+{{< /notice >}}

--- a/docs/content/en/docs/languages/go.md
+++ b/docs/content/en/docs/languages/go.md
@@ -84,9 +84,9 @@ Now, let's test our first Go function with `test` command
 $ fission fn test --name <function-name>
 ```
 
-{{% notice info %}}
+{{< notice info >}}
 See [here]({{% ref "../triggers/_index.md" %}}) for how to setup different trigger for Go function.
-{{% /notice %}}
+{{< /notice >}}
 
 ### HTTP requests and HTTP responses
 
@@ -277,10 +277,10 @@ Date: Sat, 27 Oct 2018 15:00:14 GMT
 
 ##### Setting Status Codes
 
-{{% notice warning %}}
+{{< notice warning >}}
 **Always write response status code before writing response body!**
 Otherwise, the client may receive unexpected status code.
-{{% /notice %}}
+{{< /notice >}}
 
 You can set response status code by calling function `writer.WriteHeader()`.
 However, one thing wroth to notice is if a function writes response body before status code, the client will receive HTTP 200 OK no matter what actual status code is.

--- a/docs/content/en/docs/releases/1.4.1.md
+++ b/docs/content/en/docs/releases/1.4.1.md
@@ -58,6 +58,6 @@ Now, go environment supports `go moudle` as dependencies management solution.
 
 For details, see [here](https://github.com/fission/fission/tree/master/examples/go/module-example) and [PR#1152](https://github.com/fission/fission/pull/1152).
 
-{{% notice warning %}}
+{{< notice warning >}}
 go module support require fission/go-env-1.12 version and later.
-{{% /notice %}}#
+{{< /notice >}}#

--- a/docs/content/en/docs/releases/1.7.0.md
+++ b/docs/content/en/docs/releases/1.7.0.md
@@ -75,9 +75,9 @@ Or, you can enable it by modifying environment variable of deployment of executo
   value: "true"
 ```
 
-{{% notice warning %}}
+{{< notice warning >}}
 The executor will still delete resources when you upgrade from a version prior 1.7.0 even the feature is enabled.
-{{% /notice %}}
+{{< /notice >}}
 
 For details, see [PR](https://github.com/fission/fission/pull/1453).
 
@@ -143,9 +143,9 @@ router.displayAccessLog=true
 
 when using helm to deploy 1.7.0. Or, you can change the environment variable `DISPLAY_ACCESS_LOG` of router deployment to `"true"`.  
 
-{{% notice warning %}}
+{{< notice warning >}}
 Once enabling endpoint access log, the router resource utilization increases when under heavy workloads.
-{{% /notice %}}
+{{< /notice >}}
 
 For details, see [PR](https://github.com/fission/fission/pull/1400).
 

--- a/docs/content/en/docs/releases/1.8.0.md
+++ b/docs/content/en/docs/releases/1.8.0.md
@@ -34,11 +34,11 @@ $ fission env create --name go \
 
 Now you are able to configure fetcher resource setting before helm installation.
 
-{{% notice warning %}}
+{{< notice warning >}}
 Fetcher is for downloading or uploading archive.</br>
 Low resource `limits` will increase the function specialization time and make specialization timeout.</br>
 Normally, you don't need to change the default value, unless necessary.
-{{% /notice %}}
+{{< /notice >}}
 
 ```yaml
 fetcher:

--- a/docs/content/en/docs/spec/podspec/envvar.md
+++ b/docs/content/en/docs/spec/podspec/envvar.md
@@ -6,10 +6,10 @@ date: 2019-12-06T17:02:55+08:00
 Functions sometimes require to pass-in parameter through environment variable to control internal behavior of a function like `GOMAXPROCS` for Go or you may want to expose secret/configmap as environment variable.
 In such cases, we can add `env` to PodSpec.
 
-{{% notice info %}}
+{{< notice info >}}
 As Docker doesn't support to change configuration of a container once it's created.
 To ensure different executor types have consistent behavior, Fission only supports to set environment variable at Environment-level now.
-{{% /notice %}}
+{{< /notice >}}
 
 ## Add environment variable
 

--- a/docs/content/en/docs/triggers/http-trigger.md
+++ b/docs/content/en/docs/triggers/http-trigger.md
@@ -16,11 +16,11 @@ $ curl http://$FISSION_ROUTER/hello
 Hello World!
 ```
 
-{{% notice info %}}
+{{< notice info >}}
 FISSION_ROUTER is the externally-visible address of your
 Fission router service.  For how to set up environment variable
 `FISSION_ROUTER`, see [here]({{% ref "../installation/env_vars.en.md" %}})
-{{% /notice %}}
+{{< /notice >}}
 
 Also, we can create a trigger contains URL parameter by putting placeholders in value of `--url` flag.
 
@@ -36,9 +36,9 @@ $ fission httptrigger create --method GET \
     --url "/guestbook/messages/{id:[0-9]+}" --function restapi-get
 ```
 
-{{% notice info %}}
+{{< notice info >}}
 Learn how to access URL parameters in function to develop a **REST API**, please visit [here]({{% ref "../usage/accessing-url-params.md" %}})
-{{% /notice %}}
+{{< /notice >}}
 
 If you want to use Kubernetes Ingress for the HTTP Trigger, you can provide the `--createingress` flag and a hostname.
 If the hostname is not provided, it defaults to "*", which indicates a wildcard host.

--- a/docs/content/en/docs/triggers/message-queue-trigger/_index.md
+++ b/docs/content/en/docs/triggers/message-queue-trigger/_index.md
@@ -30,9 +30,9 @@ $ fission mqtrigger create --name hello --function node --topic foobar \
 
 If a function returns with 200 HTTP status code, the MQTrigger will send the response body to `resptopic`; otherwise, MQTrigger will retry multiple times until reach `maxretries` and sends to `errortopic` if all invocations failed.
 
-{{% notice warning %}}
+{{< notice warning >}}
 Currently, only **NATS Streaming** and **Kafka** type of message queue trigger supports error topic.
-{{% /notice %}}
+{{< /notice >}}
 
 ```bash
 $ fission mqt create --name hellomsg --function hello --mqtype nats-streaming --topic newfile --resptopic newfileresponse

--- a/docs/content/en/docs/triggers/message-queue-trigger/kafka.md
+++ b/docs/content/en/docs/triggers/message-queue-trigger/kafka.md
@@ -25,11 +25,11 @@ Before we dive into details, let's walk through overall flow of event and functi
 4. Fission Kafka trigger takes the response of consumer function (consumerfunc) and drops the message in a response topic named `output`.
    If there is an error, the message is dropped in error topic named `error`.
 
-{{% notice info %}}
+{{< notice info >}}
 Fission supports Kafka [record headers](https://issues.apache.org/jira/browse/KAFKA-4208).
 Make sure you set correct version of Kafka to `kafka.version` in values.yaml while installing Fission.
 For more details please refer to Extra configuration section [here](https://github.com/fission/fission/tree/master/charts/#extra-configuration-for-fission-all).
-{{% /notice %}}
+{{< /notice >}}
 
 ## Building the app
 

--- a/docs/content/en/docs/triggers/message-queue-trigger/nats-streaming.md
+++ b/docs/content/en/docs/triggers/message-queue-trigger/nats-streaming.md
@@ -3,10 +3,10 @@ title: "NATS Streaming"
 weight: 2
 ---
 
-{{% notice info %}}
+{{< notice info >}}
 Fission uses [**NATS Streaming**](https://github.com/nats-io/nats-streaming-server) instead of pure [NATS](https://nats.io/) as the default message queue service.</br>
 Please ensure you use the correct library to connect to NATS Streaming service.
-{{% /notice %}}
+{{< /notice >}}
 
 ## Installation
 
@@ -33,9 +33,9 @@ NAME             TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
 nats-streaming   ClusterIP   10.97.32.55   <none>        4222/TCP   6d
 ```
 
-{{% notice info %}}
+{{< notice info >}}
 For further nats-streaming configuration/operation, please visit [NATS docs](https://docs.nats.io/).
-{{% /notice %}}
+{{< /notice >}}
 
 ## Connection Information
 

--- a/docs/content/en/docs/usage/access-secret-cfgmap-in-function.en.md
+++ b/docs/content/en/docs/usage/access-secret-cfgmap-in-function.en.md
@@ -115,15 +115,15 @@ Secret: TESTVALUE
 
 ## Updating Secrets and ConfigMaps
 
-{{% notice note %}}
+{{< notice note >}}
 If you have a large number of functions using a configmap or secret, updating that configmap or secret will cause a large number of pods getting re-created.
 Please make sure that the cluster has enough capacity to accommodate the short spike of many pods getting terminated and new once getting created.
-{{% /notice %}}
+{{< /notice >}}
 
 If you update the configmap or secret - the same will be updated in the function pods and newer value of configmap/secret will be used for executing functions.
 The time it takes for the change to reflect depends on the time it takes for rolling update to finish.
 
-{{% notice note %}}
+{{< notice note >}}
 In Fission version prior to 1.4.
 If the Secret or ConfigMap value is updated, the function will not get the updated and may get a cached older value.
-{{% /notice %}}
+{{< /notice >}}

--- a/docs/content/en/docs/usage/executor.en.md
+++ b/docs/content/en/docs/usage/executor.en.md
@@ -30,9 +30,9 @@ $ kubectl -n fission-function get pod -l environmentName=test
 
 Now, you shall see only one pod for the environment we just created.
 
-{{% notice warning %}}
+{{< notice warning >}}
 With `--poolsize 0`, the executor will not be able to specialize any function due to no generic pod in pool.
-{{% /notice %}}
+{{< /notice >}}
 
 If you want to set resource requests/limits for all functions use the same environment, you can provide extra min/max cpu & memory flags to set them at **environment-level**. For example, we want to limit an environment's min/max cpu to 100m/200m and min/max memory to 128Mi/256Mi.
 
@@ -83,9 +83,9 @@ NAME              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 foobar-hhytbcx4   1         1         1            1           51s
 ```
 
-{{% notice warning %}}
+{{< notice warning >}}
 With `--minscale 0`, a function will experience **long** cold-start time since it takes time for executor to create/scale deployment to 1 replica.
-{{% /notice %}}
+{{< /notice >}}
 
 #### Eliminating cold start
 

--- a/docs/content/en/docs/usage/private-registry.md
+++ b/docs/content/en/docs/usage/private-registry.md
@@ -7,10 +7,10 @@ With 1.7.0+, you can specify which credential to use for kubelet to pull images 
 
 First, you need to follow the [kubernetes guide](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to create the secret.
 
-{{% notice warning %}}
+{{< notice warning >}}
 The secret must be created in the same namespace where the function pods created.<br>
 For example, if the function pods are in the `fission-function` namespace, you need to create the secret in `fission-function` as well.
-{{% /notice %}}
+{{< /notice >}}
 
 Then, specify the secret when creating the environment.
 
@@ -45,7 +45,7 @@ items:
 
 ```
 
-{{% notice warning %}}
+{{< notice warning >}}
 Fission won't check if a secret exists nor examining whether the secret setting works as expected.<br>
 You have to check the pod status to ensure everything works as expected.
-{{% /notice %}}
+{{< /notice >}}

--- a/docs/content/en/docs/workflows/_index.en.md
+++ b/docs/content/en/docs/workflows/_index.en.md
@@ -5,9 +5,9 @@ description: >
   Workflow system on top of Fission
 ---
 
-{{% notice info %}}
+{{< notice info >}}
 Fission Workflow only supports Fission 0.4.1 ~ 0.12.0
-{{% /notice %}}
+{{< /notice >}}
 
 #### Prerequisites
 


### PR DESCRIPTION
Prior to Hacktoberfest event I found Fission project and decided to check it out.
Following the documentation I was not able to configure `helm` easily due to missing
notices (namely the one that tells you to skip configuration if `helm` is version 3):
https://docs.fission.io/docs/installation/#helm

This pull request fixes missing notices in the documentation.

![image](https://user-images.githubusercontent.com/3730149/94979713-0de96980-052d-11eb-9018-70800a78a643.png)

The correct format for shortcodes without markdown appears to be
in the form of `{{< shortcode >}}` instead of `{{% shortcode %}}`:
https://gohugo.io/content-management/shortcodes/#shortcodes-without-markdown

> For future reference: replacement was done using VS Code search and replace regex:
```
\{\{% (/?notice.*) %\}\} <=> {{< $1 >}}
```