### PR TITLE
feat: update nixos guide for fission cli

### DIFF
--- a/docs/content/en/docs/installation/_index.en.md
+++ b/docs/content/en/docs/installation/_index.en.md
@@ -257,6 +257,11 @@ $ curl -Lo fission https://github.com/fission/fission/releases/download/{{% rele
     && chmod +x fission && sudo mv fission /usr/local/bin/
 ```
 {{< /tab >}}
+{{< tab "NixOS" >}}
+```sh
+$ nix-env -iA nixos.fission
+```
+{{< /tab >}}
 {{< tab "Windows" >}}
 For Windows, you can use the linux binary on WSL. Or you can download
 this windows executable: [fission.exe](https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-cli-windows.exe)


### PR DESCRIPTION
NixOS disallows arbitrary binary execution by default so the way described under linux tab won't work. 
I have contributed this package to nixos/nixpkgs and it is now merged into unstable (from master branch), so I would also like to add a guide for people reading this docs.

https://search.nixos.org/packages?channel=unstable&show=fission&from=0&size=50&sort=relevance&query=fission