### PR TITLE
Update _index.en.md

### DIFF
--- a/docs/content/en/docs/installation/_index.en.md
+++ b/docs/content/en/docs/installation/_index.en.md
@@ -180,7 +180,6 @@ Choose _one_ of the following commands to run:
 ```bash
 $ kubectl create -k "github.com/fission/fission/crds/v1?ref={{% release-version %}}"
 $ export FISSION_NAMESPACE="fission"
-$ kubectl create namespace $FISSION_NAMESPACE
 $ kubectl config set-context --current --namespace=$FISSION_NAMESPACE
 $ kubectl apply -f https://github.com/fission/fission/releases/download/{{% release-version %}}/fission-all-{{% release-version %}}.yaml
 ```


### PR DESCRIPTION
We are already creating the `fission` namespace, and later on we export it to `FISSION_NAMESPACE` variable.
~~~
gkadam  ~  k8s  kind  export FISSION_NAMESPACE="fission"
gkadam  ~  k8s  kind  kubectl create namespace $FISSION_NAMESPACE
Error from server (AlreadyExists): namespaces "fission" already exists
gkadam  ~  k8s  kind  echo $FISSION_NAMESPACE                                                                                                                                                                                          1 
fission
~~~
Hence removed the instruction to create the namespace again under this section to avoid confusion.