### PR TITLE
Update timer.md with correct `cron string specifications`

### DIFF
--- a/docs/content/en/docs/usage/triggers/timer.md
+++ b/docs/content/en/docs/usage/triggers/timer.md
@@ -6,7 +6,7 @@ weight: 4
 
 Time-based triggers invoke functions based on time.
 They can run once or repeatedly.
-They're specified using [cron string specifications](https://en.wikipedia.org/wiki/Cron):
+They're specified using [cron string specifications](https://pkg.go.dev/github.com/robfig/cron):
 
 ```bash
 $ fission timer create --name halfhourly --function hello --cron "0 */30 * * * *"


### PR DESCRIPTION
Update the timer `cron string specifications` to the correct one. The one on the wiki has the wrong cron string formation - not matching to the library we are using here.